### PR TITLE
fix a compile error (since one arguement of get_nth_char has changed fro...

### DIFF
--- a/src/im/keyboard/keyboard.c
+++ b/src/im/keyboard/keyboard.c
@@ -560,7 +560,7 @@ INPUT_RETURN_VALUE FcitxKeyboardDoInput(void *arg, FcitxKeySym sym, unsigned int
                 {
                     if (keyboard->cursorPos > 0) {
                         size_t len = fcitx_utf8_strlen(keyboard->buffer);
-                        char* pos = fcitx_utf8_get_nth_char(keyboard->buffer, len - 1);
+                        char *pos = fcitx_utf8_get_nth_char(keyboard->buffer, len - 1);
                         keyboard->cursorPos = pos - keyboard->buffer;
                         memset(keyboard->buffer + keyboard->cursorPos, 0, sizeof(char) * (slen - keyboard->cursorPos));
                         return IRV_DISPLAY_CANDWORDS;

--- a/src/im/pinyin/py.c
+++ b/src/im/pinyin/py.c
@@ -2497,7 +2497,7 @@ void PYAddUserPhraseFromCString(void* arg, FcitxModuleFunctionArg args)
 
     int i = 0;
     while (*strHZ) {
-        unsigned int chr;
+        uint32_t chr;
 
         sp = fcitx_utf8_get_char(strHZ, &chr);
         size_t len = sp - strHZ;

--- a/src/lib/fcitx-utils/utf8.c
+++ b/src/lib/fcitx-utils/utf8.c
@@ -45,7 +45,7 @@ fcitx_utf8_strlen(const char *s)
     unsigned int l = 0;
 
     while (*s) {
-        unsigned int chr;
+        uint32_t chr;
 
         s = fcitx_utf8_get_char(s, &chr);
         l++;
@@ -84,7 +84,7 @@ int fcitx_utf8_char_len(const char *in)
 }
 
 FCITX_EXPORT_API
-int fcitx_ucs4_char_len(unsigned int c)
+int fcitx_ucs4_char_len(uint32_t c)
 {
     if (c < 0x00080) {
         return 1;
@@ -103,7 +103,7 @@ int fcitx_ucs4_char_len(unsigned int c)
 }
 
 FCITX_EXPORT_API
-int fcitx_ucs4_to_utf8(unsigned int c, char* output)
+int fcitx_ucs4_to_utf8(uint32_t c, char* output)
 {
     if (c < 0x00080) {
         output[0] = (char) (c & 0xFF);
@@ -151,7 +151,7 @@ int fcitx_ucs4_to_utf8(unsigned int c, char* output)
 
 FCITX_EXPORT_API
 char *
-fcitx_utf8_get_char(const char *i, unsigned int *chr)
+fcitx_utf8_get_char(const char *i, uint32_t *chr)
 {
     const unsigned char* in = (const unsigned char *)i;
     if (!(in[0] & 0x80)) {
@@ -198,7 +198,7 @@ FCITX_EXPORT_API
 int fcitx_utf8_strncmp(const char *s1, const char *s2, int n)
 {
     // Seems to work.
-    unsigned int c1, c2;
+    uint32_t c1, c2;
     int i;
 
     for (i = 0; i < n; i++) {
@@ -225,12 +225,12 @@ int fcitx_utf8_strncmp(const char *s1, const char *s2, int n)
 }
 
 FCITX_EXPORT_API
-char* fcitx_utf8_get_nth_char(char* s, unsigned int n)
+char* fcitx_utf8_get_nth_char(char* s, size_t n)
 {
     unsigned int l = 0;
 
     while (*s && l < n) {
-        unsigned int chr;
+        uint32_t chr;
 
         s = fcitx_utf8_get_char(s, &chr);
         l++;
@@ -324,7 +324,7 @@ FCITX_EXPORT_API
 int fcitx_utf8_check_string(const char *s)
 {
     while (*s) {
-        unsigned int chr;
+        uint32_t chr;
 
         if (fcitx_utf8_get_char_validated(s, 6) < 0)
             return 0;
@@ -339,7 +339,7 @@ FCITX_EXPORT_API
 void fcitx_utf8_strncpy(char* str, const char* s, size_t byte)
 {
     while (*s) {
-        unsigned int chr;
+        uint32_t chr;
 
         const char* next = fcitx_utf8_get_char(s, &chr);
         size_t diff = next - s;
@@ -363,7 +363,7 @@ size_t fcitx_utf8_strnlen(const char* str, size_t byte)
 {
     size_t len = 0;
     while (*str && byte > 0) {
-        unsigned int chr;
+        uint32_t chr;
 
         const char* next = fcitx_utf8_get_char(str, &chr);
         size_t diff = next - str;

--- a/src/module/chttrans/chttrans.c
+++ b/src/module/chttrans/chttrans.c
@@ -258,7 +258,7 @@ char *ConvertGBKSimple2Tradition(FcitxChttrans* transState, const char *strHZ)
             while (getline(&strBuf, &bufLen, fp) != -1) {
                 simple2trad_t *s2t;
                 char *ps;
-                unsigned int wc;
+                uint32_t wc;
 
                 ps = fcitx_utf8_get_char(strBuf, &wc);
                 s2t = (simple2trad_t*) malloc(sizeof(simple2trad_t));
@@ -280,7 +280,7 @@ char *ConvertGBKSimple2Tradition(FcitxChttrans* transState, const char *strHZ)
         ps = strHZ;
         ret[0] = '\0';
         for (; i < len; ++i) {
-            unsigned int wc;
+            uint32_t wc;
             simple2trad_t *s2t = NULL;
             int chr_len = fcitx_utf8_char_len(ps);
             char *nps;
@@ -360,7 +360,7 @@ char *ConvertGBKTradition2Simple(FcitxChttrans* transState, const char *strHZ)
             while (getline(&strBuf, &bufLen, fp) != -1) {
                 simple2trad_t *t2s;
                 char *ps;
-                unsigned int wc;
+                uint32_t wc;
 
                 ps = fcitx_utf8_get_char(strBuf, &wc);
                 t2s = (simple2trad_t*) malloc(sizeof(simple2trad_t));
@@ -384,7 +384,7 @@ char *ConvertGBKTradition2Simple(FcitxChttrans* transState, const char *strHZ)
         ps = strHZ;
         ret[0] = '\0';
         for (; i < len; ++i) {
-            unsigned int wc;
+            uint32_t wc;
             simple2trad_t *t2s = NULL;
             int chr_len = fcitx_utf8_char_len(ps);
             char *nps;

--- a/src/module/fullwidthchar/fullwidthchar.c
+++ b/src/module/fullwidthchar/fullwidthchar.c
@@ -159,7 +159,7 @@ char* ProcessFullWidthChar(void* arg, const char* str)
         const char* ps = str;
         ret[0] = '\0';
         for (; i < len; ++i) {
-            unsigned int wc;
+            uint32_t wc;
             int chr_len = fcitx_utf8_char_len(ps);
             char *nps;
             nps = fcitx_utf8_get_char(ps , &wc);


### PR DESCRIPTION
...m uint to size_t), alse use uint32_t\* when calling utf8 functions (althoug this shouldn't be a problem for almost all architectures)
