### PR TITLE
主窗口未激活时,Ctrl+Shift切换输入法仍然有效的修复

### DIFF
--- a/src/lib/fcitx/ime.c
+++ b/src/lib/fcitx/ime.c
@@ -580,11 +580,11 @@ INPUT_RETURN_VALUE FcitxInstanceProcessKey(
 
                     input->keyReleased = KR_OTHER;
                 } else if (fc->bIMSwitchKey && (FcitxHotkeyIsHotKey(sym, state, imSWNextKey1[fc->iIMSwitchKey]) || FcitxHotkeyIsHotKey(sym, state, imSWNextKey2[fc->iIMSwitchKey]))) {
-                    if (input->keyReleased == KR_SWITCH_IM) {
+                    if (FcitxInstanceGetCurrentState(instance) == IS_ACTIVE && input->keyReleased == KR_SWITCH_IM) {
                         FcitxInstanceSwitchIMByIndex(instance, -1);
                     }
                 } else if (fc->bIMSwitchKey && (FcitxHotkeyIsHotKey(sym, state, imSWPrevKey1[fc->iIMSwitchKey]) || FcitxHotkeyIsHotKey(sym, state, imSWPrevKey2[fc->iIMSwitchKey]))) {
-                    if (input->keyReleased == KR_SWITCH_IM_REVERSE) {
+                    if (FcitxInstanceGetCurrentState(instance) == IS_ACTIVE && input->keyReleased == KR_SWITCH_IM_REVERSE) {
                         FcitxInstanceSwitchIMByIndex(instance, -2);
                     }
                 } else if ((FcitxHotkeyIsHotKey(sym, state, switchKey1[fc->iSwitchKey]) || FcitxHotkeyIsHotKey(sym, state, switchKey2[fc->iSwitchKey])) && input->keyReleased == KR_SWITCH && !fc->bDoubleSwitchKey) {
@@ -896,15 +896,17 @@ void FcitxInstanceSwitchIMByIndex(FcitxInstance* instance, int index)
     if (index < -2 || index >= iIMCount)
         return;
     else if (index == -2) {
-        if (instance->iIMIndex > 0)
+        /*if (instance->iIMIndex > 0)
             index = instance->iIMIndex -1;
         else
-            index = iIMCount - 1;
+            index = iIMCount - 1;*/
+        index = (instance->iIMIndex - 1) % iIMCount + 1;
     } else if (index == -1) {
-        if (instance->iIMIndex >= (iIMCount - 1))
+        /*if (instance->iIMIndex >= (iIMCount - 1))
             index = 0;
         else
-            index = instance->iIMIndex + 1;
+            index = instance->iIMIndex + 1;*/
+        index = (instance->iIMIndex + 1) % iIMCount + 1;
     }
     if (index == 0)
         FcitxInstanceCloseIM(instance, FcitxInstanceGetCurrentIC(instance));


### PR DESCRIPTION
在执行切换前先判断主窗口是否处于激活态,是则可以切换,否则,不切换.
并修改输入法切换方式为循环切换,即切换过程中不隐藏主窗口,所以,希望能再加上英文输入法,使其能够和中文输入法一起循环切换. :-)
