### PR TITLE
add missing lsuper and rsuper in keys.c, reorder keys.c so that it is th...

### DIFF
--- a/src/lib/fcitx-config/fcitx-config.c
+++ b/src/lib/fcitx-config/fcitx-config.c
@@ -1220,9 +1220,11 @@ boolean FcitxConfigSaveConfigFileFp(FILE* fp, FcitxGenericConfig *config, FcitxC
 
             if (!option) {
                 if (optiondesc->rawDefaultValue)
-                    fprintf(fp, "%s=%s\n", optiondesc->optionName, optiondesc->rawDefaultValue);
+                    fprintf(fp, "%s=%s\n", optiondesc->optionName,
+                            optiondesc->rawDefaultValue);
                 else
-                    FcitxLog(FATAL, _("no default option for %s/%s"), groupdesc->groupName, optiondesc->optionName);
+                    FcitxLog(FATAL, _("no default option for %s/%s"),
+                             groupdesc->groupName, optiondesc->optionName);
             } else {
                 FcitxConfigSyncValue(config, group, option, Value2Raw);
                 fprintf(fp, "%s=%s\n", option->optionName, option->rawValue);
@@ -1389,7 +1391,8 @@ void FcitxConfigResetConfigToDefaultValue(FcitxGenericConfig* config)
             }
 
             if (!codesc->rawDefaultValue) {
-                /* ignore it, actually if it doesn't have a default value, the reset is meaning less */
+                /* ignore it, actually the reset is meaningless
+                 * if it doesn't have a default value. */
                 continue;
             }
 

--- a/src/lib/fcitx/keys.c
+++ b/src/lib/fcitx/keys.c
@@ -133,6 +133,53 @@ FcitxHotkey FCITX_RALT_RSHIFT2[2] = {
     {NULL, 0, 0},
 };
 
+FCITX_EXPORT_API
+FcitxHotkey FCITX_LCTRL_LSUPER[2] = {
+    {NULL, FcitxKey_Super_L, FcitxKeyState_Ctrl | FcitxKeyState_Super},
+    {NULL, FcitxKey_Control_L, FcitxKeyState_Ctrl | FcitxKeyState_Super},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_LCTRL_LSUPER2[2] = {
+    {NULL, FcitxKey_Super_L, FcitxKeyState_Ctrl},
+    {NULL, 0, 0},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_RCTRL_RSUPER[2] = {
+    {NULL, FcitxKey_Super_R, FcitxKeyState_Ctrl | FcitxKeyState_Super},
+    {NULL, FcitxKey_Control_R, FcitxKeyState_Ctrl | FcitxKeyState_Super},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_RCTRL_RSUPER2[2] = {
+    {NULL, FcitxKey_Super_R, FcitxKeyState_Ctrl},
+    {NULL, 0, 0},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_LALT_LSUPER[2] = {
+    {NULL, FcitxKey_Super_L, FcitxKeyState_Alt | FcitxKeyState_Super},
+    {NULL, FcitxKey_Alt_L, FcitxKeyState_Alt | FcitxKeyState_Super},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_LALT_LSUPER2[2] = {
+    {NULL, FcitxKey_Super_L, FcitxKeyState_Alt},
+    {NULL, 0, 0},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_RALT_RSUPER[2] = {
+    {NULL, FcitxKey_Super_R, FcitxKeyState_Alt | FcitxKeyState_Super},
+    {NULL, FcitxKey_Alt_R, FcitxKeyState_Alt | FcitxKeyState_Super},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_RALT_RSUPER2[2] = {
+    {NULL, FcitxKey_Super_R, FcitxKeyState_Alt},
+    {NULL, 0, 0},
+};
 
 FCITX_EXPORT_API
 FcitxHotkey FCITX_SEMICOLON[2] = {
@@ -141,8 +188,26 @@ FcitxHotkey FCITX_SEMICOLON[2] = {
 };
 
 FCITX_EXPORT_API
-FcitxHotkey FCITX_SEPARATOR[2] = {
-    {NULL, FcitxKey_apostrophe, FcitxKeyState_None},
+FcitxHotkey FCITX_SPACE[2] = {
+    {NULL, FcitxKey_space, FcitxKeyState_None},
+    {NULL, 0, 0},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_SHIFT_SPACE[2] = {
+    {NULL, FcitxKey_space, FcitxKeyState_Shift},
+    {NULL, 0, 0},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_SHIFT_ENTER[2] = {
+    {NULL, FcitxKey_Return, FcitxKeyState_Shift},
+    {NULL, FcitxKey_KP_Enter, FcitxKeyState_Shift},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_TAB[2] = {
+    {NULL, FcitxKey_Tab, FcitxKeyState_None},
     {NULL, 0, 0},
 };
 
@@ -159,20 +224,14 @@ FcitxHotkey FCITX_PERIOD[2] = {
 };
 
 FCITX_EXPORT_API
-FcitxHotkey FCITX_SPACE[2] = {
-    {NULL, FcitxKey_space, FcitxKeyState_None},
-    {NULL, 0, 0},
-};
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_TAB[2] = {
-    {NULL, FcitxKey_Tab, FcitxKeyState_None},
-    {NULL, 0, 0},
-};
-
-FCITX_EXPORT_API
 FcitxHotkey FCITX_CTRL_5[2] = {
     {NULL, FcitxKey_5, FcitxKeyState_Ctrl},
+    {NULL, 0, 0},
+};
+
+FCITX_EXPORT_API
+FcitxHotkey FCITX_SEPARATOR[2] = {
+    {NULL, FcitxKey_apostrophe, FcitxKeyState_None},
     {NULL, 0, 0},
 };
 
@@ -186,18 +245,6 @@ FCITX_EXPORT_API
 FcitxHotkey FCITX_LCTRL[2] = {
     {NULL, FcitxKey_Control_L, FcitxKeyState_None},
     {NULL, FcitxKey_Control_L, FcitxKeyState_Ctrl},
-};
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_LALT[2] = {
-    {NULL, FcitxKey_Alt_L, FcitxKeyState_None},
-    {NULL, FcitxKey_Alt_L, FcitxKeyState_Alt},
-};
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_RALT[2] = {
-    {NULL, FcitxKey_Alt_L, FcitxKeyState_None},
-    {NULL, FcitxKey_Alt_R, FcitxKeyState_Alt},
 };
 
 FCITX_EXPORT_API
@@ -231,65 +278,27 @@ FcitxHotkey FCITX_ALT_RSHIFT[2] = {
 };
 
 FCITX_EXPORT_API
-FcitxHotkey FCITX_LCTRL_LSUPER[2] = {
-    {NULL, FcitxKey_Super_L, FcitxKeyState_Ctrl | FcitxKeyState_Super},
-    {NULL, FcitxKey_Control_L, FcitxKeyState_Ctrl | FcitxKeyState_Super},
+FcitxHotkey FCITX_LALT[2] = {
+    {NULL, FcitxKey_Alt_L, FcitxKeyState_None},
+    {NULL, FcitxKey_Alt_L, FcitxKeyState_Alt},
 };
 
 FCITX_EXPORT_API
-FcitxHotkey FCITX_LCTRL_LSUPER2[2] = {
-    {NULL, FcitxKey_Super_L, FcitxKeyState_Ctrl},
-    {NULL, 0, 0},
+FcitxHotkey FCITX_RALT[2] = {
+    {NULL, FcitxKey_Alt_R, FcitxKeyState_None},
+    {NULL, FcitxKey_Alt_R, FcitxKeyState_Alt},
 };
 
 FCITX_EXPORT_API
-FcitxHotkey FCITX_RCTRL_RSUPER[2] = {
-    {NULL, FcitxKey_Super_R, FcitxKeyState_Ctrl | FcitxKeyState_Super},
-    {NULL, FcitxKey_Control_R, FcitxKeyState_Ctrl | FcitxKeyState_Super},
+FcitxHotkey FCITX_LSUPER[2] = {
+    {NULL, FcitxKey_Super_L, FcitxKeyState_None},
+    {NULL, FcitxKey_Super_L, FcitxKeyState_Super},
 };
 
 FCITX_EXPORT_API
-FcitxHotkey FCITX_RCTRL_RSUPER2[2] = {
-    {NULL, FcitxKey_Super_R, FcitxKeyState_Ctrl},
-    {NULL, 0, 0},
+FcitxHotkey FCITX_RSUPER[2] = {
+    {NULL, FcitxKey_Super_R, FcitxKeyState_None},
+    {NULL, FcitxKey_Super_R, FcitxKeyState_Super},
 };
-
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_LALT_LSUPER[2] = {
-    {NULL, FcitxKey_Super_L, FcitxKeyState_Alt | FcitxKeyState_Super},
-    {NULL, FcitxKey_Alt_L, FcitxKeyState_Alt | FcitxKeyState_Super},
-};
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_LALT_LSUPER2[2] = {
-    {NULL, FcitxKey_Super_L, FcitxKeyState_Alt},
-    {NULL, 0, 0},
-};
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_RALT_RSUPER[2] = {
-    {NULL, FcitxKey_Super_R, FcitxKeyState_Alt | FcitxKeyState_Super},
-    {NULL, FcitxKey_Alt_R, FcitxKeyState_Alt | FcitxKeyState_Super},
-};
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_RALT_RSUPER2[2] = {
-    {NULL, FcitxKey_Super_R, FcitxKeyState_Alt},
-    {NULL, 0, 0},
-};
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_SHIFT_SPACE[2] = {
-    {NULL, FcitxKey_space, FcitxKeyState_Shift},
-    {NULL, 0, 0},
-};
-
-FCITX_EXPORT_API
-FcitxHotkey FCITX_SHIFT_ENTER[2] = {
-    {NULL, FcitxKey_Return, FcitxKeyState_Shift},
-    {NULL, FcitxKey_KP_Enter, FcitxKeyState_Shift},
-};
-
 
 // kate: indent-mode cstyle; space-indent on; indent-width 0;


### PR DESCRIPTION
...e same with that in keys.h, correct a typo for ralt

Not sure if this deserves a back port to either 4.2.{4,5,6} but it's definitely a bug.
