### PR TITLE
[signal] use _exit instead of non-reentrant exit

### DIFF
--- a/src/core/errorhandler.c
+++ b/src/core/errorhandler.c
@@ -180,12 +180,12 @@ void OnException(int signo)
     case SIGBUS:
     case SIGILL:
     case SIGFPE:
-        exit(1);
+        _exit(1);
         break;
     default:
         {
             if (!instance || !instance->initialized) {
-                exit(1);
+                _exit(1);
                 break;
             }
 


### PR DESCRIPTION
By replacing a library it currently uses, a SIGILL is sent to fcitx And followed by a SIGSEGV. After that, SIGTERM can't terminate it. I suspect it got stuck in the `exit` call. 

Whatever, `exit` should not be used in a signal handler.
