### PR TITLE
修复切换输入法bug

### DIFF
--- a/src/im/keyboard/keyboard.c
+++ b/src/im/keyboard/keyboard.c
@@ -545,7 +545,7 @@ void FcitxKeyboardOnClose(void* arg, FcitxIMCloseEventType event)
     } else if (event == CET_ChangeByInactivate) {
         FcitxKeyboardCommitBuffer(keyboard);
     } else if (event == CET_ChangeByUser) {
-        FcitxKeyboardCommitBuffer(keyboard);
+        FcitxKeyboardResetIM(keyboard);
     }
 }
 


### PR DESCRIPTION
问题是这样的.
1 在中文状态输入几个字母('abcd'),不按空格也不按回车,直接ctrl+space切换到英文
2 在英文输入状态下无论输入什么内容(比如'hijk'),只要敲回车,则输入内容为'hijkabcd'
也就是需要在切换输入法时清空输入buffer
