### PR TITLE
Revamp FindLibkvm.cmake.

### DIFF
--- a/cmake/FindLibkvm.cmake
+++ b/cmake/FindLibkvm.cmake
@@ -6,22 +6,10 @@
 #  LIBKVM_LIBRARIES - Libraries needed to use Libkvm
 #
 
-if(LIBKVM_INCLUDE_DIR AND LIBKVM_FOUND)
-  set(Libkvm_FIND_QUIETLY TRUE)
-endif(LIBKVM_INCLUDE_DIR AND LIBKVM_FOUND)
-
 find_path(LIBKVM_INCLUDE_DIR kvm.h)
-
-set(LIBKVM_FOUND FALSE)
-
-if(LIBKVM_INCLUDE_DIR)
-    find_library(LIBKVM_LIBRARIES NAMES kvm)
-    if(LIBKVM_LIBRARIES)
-      set(LIBKVM_FOUND TRUE)
-    endif(LIBKVM_LIBRARIES)
-endif(LIBKVM_INCLUDE_DIR)
+find_library(LIBKVM_LIBRARIES NAMES kvm)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libkvm  DEFAULT_MSG  LIBKVM_INCLUDE_DIR  LIBKVM_FOUND)
+find_package_handle_standard_args(Libkvm  DEFAULT_MSG  LIBKVM_INCLUDE_DIR  LIBKVM_LIBRARIES)
 
-mark_as_advanced(LIBKVM_INCLUDE_DIR  LIBKVM_LIBRARIES  LIBKVM_LIBC_HAS_KVM_OPEN  LIBKVM_FOUND)
+mark_as_advanced(LIBKVM_INCLUDE_DIR  LIBKVM_LIBRARIES)


### PR DESCRIPTION
The most important part of this change is that if fixes the build on the BSDs with CMake >= 2.8.11. From the commit message:

Adapt it to a more modern CMake style:
 o XX_FIND_QUIETLY is already set by CMake's FindPackageHandleStandardArgs
 o Conditionally looking for libkvm only if the header was found was an
   unnecessary optimization that mostly clutters the code without much
   benefit.
 o LIBKVM_LIBC_HAS_KVM_OPEN was passed to mark_as_advanced() but was never
   being set.
 o Most importantly, naming a variable LIBKVM_FOUND is just wrong as it is
   exactly the variable that is supposed to be set by
   FindPackageHandleStandardArgs itself. It simply broke with CMake>=2.8.11.
