### PR TITLE
[core] restart in-place.

### DIFF
--- a/src/frontend/ipc/ipc.c
+++ b/src/frontend/ipc/ipc.c
@@ -721,7 +721,7 @@ static DBusHandlerResult IPCDBusEventHandler(DBusConnection *connection, DBusMes
         reply = dbus_message_new_method_return(msg);
         flush = true;
     } else if (dbus_message_is_method_call(msg, FCITX_IM_DBUS_INTERFACE, "Restart")) {
-        fcitx_utils_launch_restart();
+        FcitxInstanceRestart(instance);
         reply = dbus_message_new_method_return(msg);
         flush = true;
     }

--- a/src/lib/fcitx-utils/utils.c
+++ b/src/lib/fcitx-utils/utils.c
@@ -644,6 +644,20 @@ void fcitx_utils_launch_restart()
 }
 
 FCITX_EXPORT_API
+void fcitx_utils_restart_in_place(void)
+{
+    char* command = fcitx_utils_get_fcitx_path_with_filename("bindir", "fcitx");
+    char* const argv[] = {
+        command,
+        "-D", /* Don't start as daemon */
+        NULL
+    };
+    execvp(argv[0], argv);
+    perror("Restart failed: execvp:");
+    _exit(1);
+}
+
+FCITX_EXPORT_API
 void fcitx_utils_start_process(char** args)
 {
     /* exec command */

--- a/src/lib/fcitx-utils/utils.h
+++ b/src/lib/fcitx-utils/utils.h
@@ -472,6 +472,13 @@ extern "C" {
     void fcitx_utils_launch_restart(void);
 
     /**
+     * helper function to execute in place
+     *
+     * @return void
+     **/
+    void fcitx_utils_restart_in_place(void);
+
+    /**
      * @brief launch a process
      *
      * @param args argument and command

--- a/src/lib/fcitx/instance-internal.h
+++ b/src/lib/fcitx/instance-internal.h
@@ -158,6 +158,7 @@ struct _FcitxInstance {
     volatile boolean loadingFatalError;
     volatile boolean quietQuit;
     volatile boolean destroy;
+    volatile boolean restart;
     int fd;
     int overrideDelay;
     

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -277,6 +277,8 @@ extern "C" {
      **/
     boolean FcitxInstanceRun(int argc, char* argv[], int fd);
 
+    void FcitxInstanceRestart(FcitxInstance *instance);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/module/notificationitem/dbusmenu.c
+++ b/src/module/notificationitem/dbusmenu.c
@@ -232,7 +232,7 @@ void FcitxDBusMenuDoEvent(void* arg)
                     fcitx_utils_launch_configure_tool();
                     break;
                 case 6:
-                    fcitx_utils_launch_restart();
+                    FcitxInstanceRestart(instance);
                     break;
                 case 7:
                     FcitxInstanceEnd(instance);

--- a/src/ui/classic/classicui.c
+++ b/src/ui/classic/classicui.c
@@ -510,7 +510,7 @@ boolean MainMenuAction(FcitxUIMenu* menu, int index)
     } else if (index == length - 1) { /* Exit */
         FcitxInstanceEnd(classicui->owner);
     } else if (index == length - 2) { /* Restart */
-        fcitx_utils_launch_restart();
+        FcitxInstanceRestart(instance);
     } else if (index == length - 3) { /* Configuration */
         fcitx_utils_launch_configure_tool();
     } else if (index == length - 4) { /* Configuration */

--- a/src/ui/kimpanel/kimpanel.c
+++ b/src/ui/kimpanel/kimpanel.c
@@ -792,7 +792,7 @@ DBusHandlerResult KimpanelDBusFilter(DBusConnection* connection, DBusMessage* ms
                             fcitx_utils_launch_configure_tool();
                     }
                     else if (strcmp(s0, "restart") == 0) {
-                        fcitx_utils_launch_restart();
+                        FcitxInstanceRestart(instance);
                     }
                 } else if (strcmp("keyboard", s0) == 0) {
                     FcitxInstanceCloseIM(instance,
@@ -883,7 +883,7 @@ DBusHandlerResult KimpanelDBusFilter(DBusConnection* connection, DBusMessage* ms
         return DBUS_HANDLER_RESULT_HANDLED;
     } else if (dbus_message_is_signal(msg, "org.kde.impanel", "Restart")) {
         FcitxLog(DEBUG, "Restart");
-        fcitx_utils_launch_restart();
+        FcitxInstanceRestart(instance);
         return DBUS_HANDLER_RESULT_HANDLED;
     } else if (dbus_message_is_signal(msg, "org.kde.impanel", "Configure")) {
         FcitxLog(DEBUG, "Configure");


### PR DESCRIPTION
Use exec to restart fcitx in-place rather than as a child process.

Known issue:

Broke custom xmodmap, example:

 remove Lock = Caps_Lock
 remove control = Control_R
 keysym Caps_Lock = Control_R
 add control = Control_R
