### PR TITLE
Add missing libintl include dirs

### DIFF
--- a/tools/gui/quickphrase-editor/CMakeLists.txt
+++ b/tools/gui/quickphrase-editor/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 include_directories(
   ${QT_QTCORE_INCLUDE_DIR}
   ${QT_QTGUI_INCLUDE_DIR}
+  ${LIBINTL_INCLUDE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   )
 qt4_wrap_ui(QUICKPHRASE_EDITOR_SRCS editordialog.ui batchdialog.ui editor.ui)

--- a/tools/gui/wrapper/CMakeLists.txt
+++ b/tools/gui/wrapper/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 include_directories(
   ${QT_QTCORE_INCLUDE_DIR}
   ${QT_QTGUI_INCLUDE_DIR}
+  ${LIBINTL_INCLUDE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   )
 


### PR DESCRIPTION
Add some missing libintl include directories. Fix build on FreeBSD.
