### PR TITLE
[ui] delay UI update for 150ms to avoid quick changes

### DIFF
--- a/src/lib/fcitx/ui.c
+++ b/src/lib/fcitx/ui.c
@@ -657,11 +657,19 @@ void FcitxMenuClear(FcitxUIMenu* menu)
     utarray_clear(&menu->shell);
 }
 
+static void FcitxUIUpdate(void *arg)
+{
+    FcitxInstance *instance = arg;
+    instance->ui->ui->OnInputFocus(instance->ui->addonInstance);
+}
+
 FCITX_EXPORT_API
 void FcitxUIOnInputFocus(FcitxInstance* instance)
 {
-    if (UI_FUNC_IS_VALID(OnInputFocus))
-        instance->ui->ui->OnInputFocus(instance->ui->addonInstance);
+    if (UI_FUNC_IS_VALID(OnInputFocus)) {
+        FcitxInstanceRemoveTimeoutByFunc(instance, FcitxUIUpdate);
+        FcitxInstanceAddTimeout(instance, 100, FcitxUIUpdate, instance);
+    }
 
     FcitxInstanceProcessInputFocusHook(instance);
 
@@ -678,8 +686,10 @@ void FcitxUIOnInputFocus(FcitxInstance* instance)
 FCITX_EXPORT_API
 void FcitxUIOnInputUnFocus(struct _FcitxInstance* instance)
 {
-    if (UI_FUNC_IS_VALID(OnInputUnFocus))
-        instance->ui->ui->OnInputUnFocus(instance->ui->addonInstance);
+    if (UI_FUNC_IS_VALID(OnInputFocus)) {
+        FcitxInstanceRemoveTimeoutByFunc(instance, FcitxUIUpdate);
+        FcitxInstanceAddTimeout(instance, 150, FcitxUIUpdate, instance);
+    }
 
     FcitxInstanceProcessInputUnFocusHook(instance);
 }

--- a/src/lib/fcitx/ui.c
+++ b/src/lib/fcitx/ui.c
@@ -657,18 +657,18 @@ void FcitxMenuClear(FcitxUIMenu* menu)
     utarray_clear(&menu->shell);
 }
 
-static void FcitxUIUpdate(void *arg)
+static void FcitxUIUpdateOnUnFocus(void *arg)
 {
     FcitxInstance *instance = arg;
-    instance->ui->ui->OnInputFocus(instance->ui->addonInstance);
+    instance->ui->ui->OnInputUnFocus(instance->ui->addonInstance);
 }
 
 FCITX_EXPORT_API
 void FcitxUIOnInputFocus(FcitxInstance* instance)
 {
     if (UI_FUNC_IS_VALID(OnInputFocus)) {
-        FcitxInstanceRemoveTimeoutByFunc(instance, FcitxUIUpdate);
-        FcitxInstanceAddTimeout(instance, 100, FcitxUIUpdate, instance);
+        FcitxInstanceRemoveTimeoutByFunc(instance, FcitxUIUpdateOnUnFocus);
+        instance->ui->ui->OnInputFocus(instance->ui->addonInstance);
     }
 
     FcitxInstanceProcessInputFocusHook(instance);
@@ -686,9 +686,9 @@ void FcitxUIOnInputFocus(FcitxInstance* instance)
 FCITX_EXPORT_API
 void FcitxUIOnInputUnFocus(struct _FcitxInstance* instance)
 {
-    if (UI_FUNC_IS_VALID(OnInputFocus)) {
-        FcitxInstanceRemoveTimeoutByFunc(instance, FcitxUIUpdate);
-        FcitxInstanceAddTimeout(instance, 150, FcitxUIUpdate, instance);
+    if (UI_FUNC_IS_VALID(OnInputUnFocus)) {
+        FcitxInstanceRemoveTimeoutByFunc(instance, FcitxUIUpdateOnUnFocus);
+        FcitxInstanceAddTimeout(instance, 150, FcitxUIUpdateOnUnFocus, instance);
     }
 
     FcitxInstanceProcessInputUnFocusHook(instance);


### PR DESCRIPTION
When pressing global hot key, the application may briefly lose focus, resulting in the icon and status bar flickering. This patch makes most (if not all) such flickers disappear.
