### PR TITLE
[core] use Unity indicator-keyboard icons in Unity

### DIFF
--- a/src/ui/kimpanel/kimpanel.c
+++ b/src/ui/kimpanel/kimpanel.c
@@ -217,7 +217,7 @@ FCITX_DEFINE_PLUGIN(fcitx_kimpanel_ui, ui, FcitxUI) = {
 #define INDICATOR_KEYBOARD_PREFIX "@indicator-keyboard-"
 #define INDICATOR_KEYBOARD_LENGTH 20
 
-static boolean
+static inline boolean
 isUnity()
 {
     return fcitx_utils_strcmp0(getenv("XDG_CURRENT_DESKTOP"), "Unity") == 0;
@@ -225,13 +225,12 @@ isUnity()
 
 static void SetIMMenu(FcitxIM *pim, char** prop)
 {
-    char layout[INDICATOR_KEYBOARD_LENGTH + 3];
+    char layout[INDICATOR_KEYBOARD_LENGTH + 3] = INDICATOR_KEYBOARD_PREFIX;
     const char *icon = "";
     if (strncmp(pim->uniqueName, "fcitx-keyboard-",
                 strlen("fcitx-keyboard-")) != 0) {
         icon = pim->strIconName;
     } else if (isUnity()) {
-        strcpy(layout, INDICATOR_KEYBOARD_PREFIX);
         layout[INDICATOR_KEYBOARD_LENGTH + 0] = toupper(pim->langCode[0]);
         layout[INDICATOR_KEYBOARD_LENGTH + 1] = tolower(pim->langCode[1]);
         layout[INDICATOR_KEYBOARD_LENGTH + 2] = '\0';
@@ -245,7 +244,7 @@ static void SetIMMenu(FcitxIM *pim, char** prop)
 
 static void SetIMIcon(FcitxInstance* instance, char** prop)
 {
-    char layout[INDICATOR_KEYBOARD_LENGTH + 3];
+    char layout[INDICATOR_KEYBOARD_LENGTH + 3] = INDICATOR_KEYBOARD_PREFIX;
     const char* icon;
     char* imname;
     char* description;
@@ -262,7 +261,6 @@ static void SetIMIcon(FcitxInstance* instance, char** prop)
         if (im) {
             if (strncmp(im->uniqueName, "fcitx-keyboard-", strlen("fcitx-keyboard-")) == 0) {
                 if (isUnity()) {
-                    strcpy(layout, INDICATOR_KEYBOARD_PREFIX);
                     layout[INDICATOR_KEYBOARD_LENGTH + 0] = toupper(im->langCode[0]);
                     layout[INDICATOR_KEYBOARD_LENGTH + 1] = tolower(im->langCode[1]);
                     layout[INDICATOR_KEYBOARD_LENGTH + 2] = '\0';


### PR DESCRIPTION
In Unity, there are icons available for keyboard layouts that Fcitx could use.
