### PR TITLE
Use FCITX_WINDOW_POPUP_MENU in ClassicUI InputWindow

### DIFF
--- a/src/module/x11/x11stuff-internal.h
+++ b/src/module/x11/x11stuff-internal.h
@@ -50,6 +50,7 @@ typedef struct {
     Atom windowTypeAtom;
     Atom typeDialogAtom;
     Atom typeDockAtom;
+    Atom typePopupMenuAtom;
     Atom pidAtom;
     Atom utf8Atom;
     Atom stringAtom;

--- a/src/module/x11/x11stuff.c
+++ b/src/module/x11/x11stuff.c
@@ -288,6 +288,7 @@ X11InitAtoms(FcitxX11 *x11priv)
         "_NET_WM_WINDOW_TYPE_MENU",
         "_NET_WM_WINDOW_TYPE_DIALOG",
         "_NET_WM_WINDOW_TYPE_DOCK",
+        "_NET_WM_WINDOW_TYPE_POPUP_MENU",
         "_NET_WM_PID",
         "UTF8_STRING",
         "STRING",
@@ -303,11 +304,12 @@ X11InitAtoms(FcitxX11 *x11priv)
     x11priv->typeMenuAtom = atoms_return[1];
     x11priv->typeDialogAtom = atoms_return[2];
     x11priv->typeDockAtom = atoms_return[3];
-    x11priv->pidAtom = atoms_return[4];
-    x11priv->utf8Atom = atoms_return[5];
-    x11priv->stringAtom = atoms_return[6];
-    x11priv->compTextAtom = atoms_return[7];
-    x11priv->compManagerAtom = atoms_return[8];
+    x11priv->typePopupMenuAtom = atoms_return[4];
+    x11priv->pidAtom = atoms_return[5];
+    x11priv->utf8Atom = atoms_return[6];
+    x11priv->stringAtom = atoms_return[7];
+    x11priv->compTextAtom = atoms_return[8];
+    x11priv->compManagerAtom = atoms_return[9];
 }
 
 static boolean
@@ -399,6 +401,9 @@ X11SetWindowProperty(FcitxX11 *x11priv, Window window, FcitxXWindowType type,
         break;
     case FCITX_WINDOW_DOCK:
         wintype = &x11priv->typeDockAtom;
+        break;
+    case FCITX_WINDOW_POPUP_MENU:
+        wintype = &x11priv->typePopupMenuAtom;
         break;
     case FCITX_WINDOW_MENU:
         wintype = &x11priv->typeMenuAtom;

--- a/src/module/x11/x11stuff.h
+++ b/src/module/x11/x11stuff.h
@@ -70,6 +70,7 @@ typedef struct _FcitxRect {
 typedef enum _FcitxXWindowType {
     FCITX_WINDOW_UNKNOWN,
     FCITX_WINDOW_DOCK,
+    FCITX_WINDOW_POPUP_MENU,
     FCITX_WINDOW_MENU,
     FCITX_WINDOW_DIALOG
 } FcitxXWindowType;

--- a/src/ui/classic/InputWindow.c
+++ b/src/ui/classic/InputWindow.c
@@ -61,7 +61,7 @@ void InputWindowInit(InputWindow* inputWindow)
                         INPUTWND_HEIGHT,
                         0, 0,
                         "Fcitx Input Window",
-                        FCITX_WINDOW_DOCK,
+                        FCITX_WINDOW_POPUP_MENU,
                         &window->owner->skin.skinInputBar.background,
                         ButtonPressMask | ButtonReleaseMask  | PointerMotionMask | ExposureMask | LeaveWindowMask,
                         InputWindowMoveWindow,


### PR DESCRIPTION
InputWindow of ClassicUI should use FCITX_WINDOW_POPUP_MENU.
These are reasons:
1, it is obvious that InputWindow is not DOCK and POPUP_MENU is proper. 
2, this fixes a InputWindow's bug on Cinnamon.

Before : InputWindow covered by Cinnamon Menu.
![covered](https://cloud.githubusercontent.com/assets/1858413/6164515/58d2fc88-b2e3-11e4-9928-1f2a9f1fbd8f.png)

After : InputWindow is exposed after this pull request applied.
![uncovered](https://cloud.githubusercontent.com/assets/1858413/6164521/5d985b0a-b2e3-11e4-8546-f101496e1433.png)