### PR TITLE
[notificationitem] Fix a bug in plugin entry

### DIFF
--- a/src/module/notificationitem/notificationitem.c
+++ b/src/module/notificationitem/notificationitem.c
@@ -123,9 +123,9 @@ static void FcitxNotificationItemDestroy(void* arg);
 
 FCITX_DEFINE_PLUGIN(fcitx_notificationitem, module, FcitxModule) = {
     FcitxNotificationItemCreate,
+    NULL,
+    NULL,
     FcitxNotificationItemDestroy,
-    NULL,
-    NULL,
     NULL
 };
 


### PR DESCRIPTION
I'm not sure but FcitxNotificationItemDestroy seems be registered as SetFD func.
Is it intentional?

If it's a bug, please merge the patch.
It not, please discard this pull request.
