### PR TITLE
Make Ctrl-M work as Enter.

### DIFF
--- a/src/lib/fcitx/ime.c
+++ b/src/lib/fcitx/ime.c
@@ -219,6 +219,11 @@ void FcitxInstanceInitBuiltInHotkey(FcitxInstance *instance)
     hk.arg = instance;
     FcitxInstanceRegisterHotkeyFilter(instance, hk);
 
+    hk.hotkey = FCITX_CTRL_M;
+    hk.hotkeyhandle = ImProcessEnter;
+    hk.arg = instance;
+    FcitxInstanceRegisterHotkeyFilter(instance, hk);
+
     hk.hotkey = FCITX_ESCAPE;
     hk.hotkeyhandle = ImProcessEscape;
     hk.arg = instance;

--- a/src/lib/fcitx/keys.c
+++ b/src/lib/fcitx/keys.c
@@ -86,6 +86,12 @@ FcitxHotkey FCITX_ENTER[2] = {
 };
 
 FCITX_EXPORT_API
+FcitxHotkey FCITX_CTRL_M[2] = {
+  {NULL, FcitxKey_M, FcitxKeyState_Ctrl},
+  {NULL, 0, 0},
+};
+
+FCITX_EXPORT_API
 FcitxHotkey FCITX_LCTRL_LSHIFT[2] = {
     {NULL, FcitxKey_Shift_L, FcitxKeyState_Ctrl_Shift},
     {NULL, FcitxKey_Control_L, FcitxKeyState_Ctrl_Shift},

--- a/src/lib/fcitx/keys.h
+++ b/src/lib/fcitx/keys.h
@@ -41,6 +41,7 @@ extern "C" {
     extern FcitxHotkey FCITX_LEFT[2];
     extern FcitxHotkey FCITX_ESCAPE[2];
     extern FcitxHotkey FCITX_ENTER[2];
+    extern FcitxHotkey FCITX_CTRL_M[2];
     extern FcitxHotkey FCITX_LCTRL_LSHIFT[2];
     extern FcitxHotkey FCITX_LCTRL_LSHIFT2[2];
     extern FcitxHotkey FCITX_RCTRL_RSHIFT[2];


### PR DESCRIPTION
This key mapping cannot be achieved by the fcitx key-theme plugin, so
this little patch emerges.