### PR TITLE
Call sem_post() only on valid semaphore

### DIFF
--- a/src/lib/fcitx/instance.c
+++ b/src/lib/fcitx/instance.c
@@ -416,7 +416,9 @@ void* RunInstance(void* arg)
     return NULL;
 
 error_exit:
-    sem_post(&instance->startUpSem);
+    if (instance->sem) {
+        sem_post(&instance->startUpSem);
+    }
     FcitxInstanceEnd(instance);
     return NULL;
 }


### PR DESCRIPTION
startUpSem is valid only if sem in non-NULL.