### PR TITLE
Bug fixed: fcitx-module-x11 conflicts with Xlib under VNCServer environment

### DIFF
--- a/src/module/x11/xerrorhandler.c
+++ b/src/module/x11/xerrorhandler.c
@@ -86,7 +86,7 @@ int FcitxXErrorHandler(Display * dpy, XErrorEvent * event)
 
     if (fp)
         fclose(fp);
-    if (event->error_code != 3 && event->error_code != BadMatch) {
+    if (event->error_code != 3 && event->error_code != BadMatch && event->error_code != BadValue) {
         // xterm will generate 3
         FcitxInstanceEnd(x11handle->owner);
     }


### PR DESCRIPTION
Bug fixed: fcitx-module-x11 conflicts with Xlib under VNCServer environment, when fcitx reports "Xlib XKB extension 0.0 != 1.0".

fcitx: BadValue (integer parameter out of range for operation)

Signed-off-by: CUI Wei <ghostplant@qq.com>