### PR TITLE
fcitx-configtool.desktop: Remove MimeType entry

### DIFF
--- a/data/fcitx-configtool.desktop.in
+++ b/data/fcitx-configtool.desktop.in
@@ -4,7 +4,6 @@ _GenericName=Input Method Configuration
 _Comment=Change Fcitx Configuration
 Exec=fcitx-configtool
 Icon=fcitx
-MimeType=
 Type=Application
 Categories=Settings;
 X-KDE-StartupNotify=false


### PR DESCRIPTION
We are encountering the following lintian warning in Debian:

W: desktop-mime-but-no-exec-code
 usr/share/applications/fcitx-configtool.desktop

It seems that fcitx-configtool does not accept filename/filelist
as parameter (in fact it is only a wrapper of concrete config tools).
In this case, we should not add any MimeType key inside desktop
file.

See https://lintian.debian.org/tags/desktop-mime-but-no-exec-code.html
for more information.