### PR TITLE
Add missing include of sys/types.h

### DIFF
--- a/src/im/pinyin/py.h
+++ b/src/im/pinyin/py.h
@@ -20,6 +20,8 @@
 #ifndef _PY_H
 #define _PY_H
 
+#include <sys/types.h>
+
 #include "fcitx/ime.h"
 #include "fcitx/fcitx.h"
 #include "fcitx-utils/memory.h"

--- a/src/lib/fcitx/ui.c
+++ b/src/lib/fcitx/ui.c
@@ -22,6 +22,7 @@
 #include <libintl.h>
 #include <stdarg.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
 #include "ui.h"
 #include "addon.h"


### PR DESCRIPTION
These files use the type 'uint', which is defined in sys/types.h,
without including the header file.

Fix build in non-glibc environment.