### PR TITLE
Changing IM by name should always work if ShareState_All

### DIFF
--- a/src/lib/fcitx/ui.c
+++ b/src/lib/fcitx/ui.c
@@ -675,7 +675,8 @@ void FcitxUIOnInputFocus(FcitxInstance* instance)
 
     boolean changed;
 
-    if (instance->lastIC == instance->CurrentIC && instance->delayedIM) {
+    if ((instance->lastIC == instance->CurrentIC || instance->config->shareState == ShareState_All)
+            && instance->delayedIM) {
         FcitxInstanceSwitchIMByName(instance, instance->delayedIM);
         changed = true;
     } else {


### PR DESCRIPTION
Hello Xuetian and Yichao

First of all, thanks a lot for your work on fcitx!

Unfortunatelly, I'm having some problems integrating fcitx in my environment because I'm using more than two keyboard layouts.

I'd like to have one shortuct to toggle between the layouts (of which one needs fcitx) and also have shortcuts to select specific keyboard layout (and use standard keyboard applet to indicate current layout, no matter whether IME is activated or not).

This should be doable with a script that switches xkb keyboard to a given layout (and if the layout needs fcitx also executes fcitx-remote with -c/-o/s).

Only problem is that fcitx-remote does not change the IME properly if text input is currently not focused when executing fcitx-remote.

This PR should fix that - it's a oneliner that changes to delayedIM on input focus no matter what if "share state among window" is "all".