### PR TITLE
Update comment of  context.h

### DIFF
--- a/src/lib/fcitx/context.h
+++ b/src/lib/fcitx/context.h
@@ -68,7 +68,7 @@ extern "C" {
     #define CONTEXT_SHOW_REMIND_STATUS "CONTEXT_SHOW_REMIND_STATUS"
     /** disable auto first candidate highlight */
     #define CONTEXT_DISABLE_AUTO_FIRST_CANDIDATE_HIGHTLIGHT "CONTEXT_DISABLE_AUTO_FIRST_CANDIDATE_HIGHTLIGHT"
-    /** disable auto first candidate highlight */
+    /** disable built-in full width punc translater module */
     #define CONTEXT_DISABLE_FULLWIDTH "CONTEXT_DISABLE_FULLWIDTH"
     /** disable punc module */
     #define CONTEXT_DISABLE_PUNC "CONTEXT_DISABLE_PUNC"


### PR DESCRIPTION
The comment above `CONTEXT_DISABLE_FULLWIDTH` should be
```
/** disable built-in full width punc translater module */
```