### PR TITLE
 when fcitxDBusWatch is null, fcitx-dbus-watch will be over 

### DIFF
--- a/src/module/dbus/dbussocket.c
+++ b/src/module/dbus/dbussocket.c
@@ -72,7 +72,7 @@ void DBusProcessEventForWatches(FcitxDBusWatch* watches, fd_set* rfds, fd_set* w
     FcitxDBusWatch *w;
 
     for (w = watches; w; w = w->next) {
-        if (dbus_watch_get_enabled(w->watch)) {
+        if (w && dbus_watch_get_enabled(w->watch)) {
             unsigned int flags = 0;
             int fd = dbus_watch_get_unix_fd(w->watch);
 


### PR DESCRIPTION
sometimes other software will infection fcitx.