### PR TITLE
Fix the problem of hotkey switch failure.

### DIFF
--- a/src/frontend/ipc/ipc.c
+++ b/src/frontend/ipc/ipc.c
@@ -645,7 +645,7 @@ static DBusHandlerResult IPCDBusEventHandler(DBusConnection *connection, DBusMes
         dbus_connection_send(connection, reply, NULL);
         dbus_message_unref(reply);
         dbus_connection_flush(connection);
-        FcitxInstanceEnd(instance);
+        FcitxInstanceEndWithKill(instance);
         return DBUS_HANDLER_RESULT_HANDLED;
     } else if (dbus_message_is_method_call(msg, FCITX_IM_DBUS_INTERFACE, "GetCurrentIM")) {
         reply = dbus_message_new_method_return(msg);

--- a/src/lib/fcitx/instance.c
+++ b/src/lib/fcitx/instance.c
@@ -450,8 +450,37 @@ void FcitxInstanceEnd(FcitxInstance* instance)
         return;
     }
 
+    if (instance->pid) {
+        FcitxInstanceWaitForEnd(instance);
+    }
+
     instance->destroy = true;
 }
+
+FCITX_EXPORT_API
+void FcitxInstanceEndWithKill(FcitxInstance* instance)
+{
+    /* avoid duplicate destroy */
+    if (instance->destroy)
+        return;
+
+    raise(SIGKILL);
+    if (!instance->initialized) {
+        if (!instance->loadingFatalError) {
+            if (!instance->quietQuit)
+                FcitxLog(ERROR, "Exiting.");
+            instance->loadingFatalError = true;
+
+            if (instance->sem) {
+                sem_post(instance->sem);
+            }
+        }
+        return;
+    }
+
+    instance->destroy = true;
+}
+
 
 FCITX_EXPORT_API
 void FcitxInstanceRealEnd(FcitxInstance* instance) {

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -148,6 +148,14 @@ extern "C" {
     void FcitxInstanceEnd(FcitxInstance* instance);
 
     /**
+     * notify the instance is end and kill all sub threads
+     *
+     * @param instance fcitx instance
+     * @return void
+     **/
+    void FcitxInstanceEndWithKill(FcitxInstance* instance);
+
+    /**
      * check whether FcitxInstanceEnd is called or not
      *
      * @param instance fcitx instance

--- a/src/lib/fcitx/keys.c
+++ b/src/lib/fcitx/keys.c
@@ -94,7 +94,7 @@ FcitxHotkey FCITX_LCTRL_LSHIFT[2] = {
 FCITX_EXPORT_API
 FcitxHotkey FCITX_LCTRL_LSHIFT2[2] = {
     {NULL, FcitxKey_Shift_L, FcitxKeyState_Ctrl},
-    {NULL, 0, 0},
+    {NULL, FcitxKey_Control_L, FcitxKeyState_Shift},
 };
 
 FCITX_EXPORT_API
@@ -118,7 +118,7 @@ FcitxHotkey FCITX_LALT_LSHIFT[2] = {
 FCITX_EXPORT_API
 FcitxHotkey FCITX_LALT_LSHIFT2[2] = {
     {NULL, FcitxKey_Shift_L, FcitxKeyState_Alt},
-    {NULL, 0, 0},
+    {NULL, FcitxKey_Alt_L, FcitxKeyState_Shift},
 };
 
 FCITX_EXPORT_API
@@ -142,7 +142,7 @@ FcitxHotkey FCITX_LCTRL_LSUPER[2] = {
 FCITX_EXPORT_API
 FcitxHotkey FCITX_LCTRL_LSUPER2[2] = {
     {NULL, FcitxKey_Super_L, FcitxKeyState_Ctrl},
-    {NULL, 0, 0},
+    {NULL, FcitxKey_Control_L, FcitxKeyState_Super},
 };
 
 FCITX_EXPORT_API
@@ -160,13 +160,13 @@ FcitxHotkey FCITX_RCTRL_RSUPER2[2] = {
 FCITX_EXPORT_API
 FcitxHotkey FCITX_LALT_LSUPER[2] = {
     {NULL, FcitxKey_Super_L, FcitxKeyState_Alt | FcitxKeyState_Super},
-    {NULL, FcitxKey_Alt_L, FcitxKeyState_Alt | FcitxKeyState_Super},
+    {NULL, FcitxKey_Alt_L,   FcitxKeyState_Alt | FcitxKeyState_Super},
 };
 
 FCITX_EXPORT_API
 FcitxHotkey FCITX_LALT_LSUPER2[2] = {
     {NULL, FcitxKey_Super_L, FcitxKeyState_Alt},
-    {NULL, 0, 0},
+    {NULL, FcitxKey_Alt_L, FcitxKeyState_Super},
 };
 
 FCITX_EXPORT_API


### PR DESCRIPTION
Dear manager:
Here is my problem,when i use hotkey to switch input method, I found it won't work in some situation.
For example, press CTRL first, then press SHIFT, hotkey switch works.
but press SHIFT first, then press CTRL, it won't work.

so i add some code, it seems works well.