### PR TITLE
fcitx-dbus-watcher should exit if Dbus daemon died

### DIFF
--- a/src/module/dbus/watcher.c
+++ b/src/module/dbus/watcher.c
@@ -117,7 +117,7 @@ int main (int argc, char* argv[])
         select(maxfd + 1, &rfds, &wfds, &efds, NULL);
     } while(1);
 
-    if (status == FCITX_DIE) {
+    if (status == FCITX_DIE || status == DBUS_DIE) {
         kill(pid, SIGTERM);
     }
 


### PR DESCRIPTION
fcitx daemon will exit if Dbus-daemon down.
fcitx-dbus-watcher should exit too.