### PR TITLE
fix: fcitx crash sometimes.

### DIFF
--- a/src/module/x11/x11stuff.c
+++ b/src/module/x11/x11stuff.c
@@ -77,6 +77,8 @@ FCITX_DEFINE_PLUGIN(fcitx_x11, module, FcitxModule) = {
 
 void* X11Create(FcitxInstance* instance)
 {
+    XInitThreads();
+
     FcitxX11 *x11priv = fcitx_utils_new(FcitxX11);
     x11priv->dpy = XOpenDisplay(NULL);
     if (x11priv->dpy == NULL)


### PR DESCRIPTION
[xcb] Unknown sequence number while processing reply
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
fcitx: xcb_io.c:643: _XReply: Assertion `!xcb_xlib_threads_sequence_lost' failed.
=========================
FCITX 4.2.9.32.25 -- Get Signal No.: 6
Date: try "date -d @1652063315" if you are using GNU date ***
ProcessID: 25771
/usr/bin/fcitx[0x401979]