### PR TITLE
Use a bigger number to avoid freezing XIM client

### DIFF
--- a/src/frontend/xim/lib/i18nX.c
+++ b/src/frontend/xim/lib/i18nX.c
@@ -253,7 +253,7 @@ static char *MakeNewAtom(CARD16 connect_id, char *atomName)
     sprintf(atomName,
             "_server%d_%d",
             connect_id,
-            ((sequence > 20)  ? (sequence = 0)  :  sequence++));
+            ((sequence > 300)  ? (sequence = 0)  :  sequence++));
     return atomName;
 }
 


### PR DESCRIPTION
1. Due to the poor implementation of libX11, XIM client may freeze when XIM server provide too many property values on the same window atom in a short time.

2. However, if we provide a bigger number here, it will reduce the possibility of using the same atom to send message. As a result, it will reduce the possibility of freezing XIM client.

3. Unfortunely, if we provide a too big number, some IM addons may freeze.

4. So, we provide a tested number 300 here to satisfy the limitations above. If libX11 improves its poor implementation one day, we can revert our fix. However, our fix should do no harm and could be left here if no one remembered it.