### PR TITLE
src/frontend/qt/qtkey.h: add missing <stdint.h> import

### DIFF
--- a/src/frontend/qt/qtkey.h
+++ b/src/frontend/qt/qtkey.h
@@ -20,6 +20,7 @@
 #ifndef _PLATFORMINPUTCONTEXT_QTKEY_H_
 #define _PLATFORMINPUTCONTEXT_QTKEY_H_
 
+#include <stdint.h>
 #include <QString>
 
 int keysymToQtKey(uint32_t keysym, const QString &text);


### PR DESCRIPTION
Without the change build fails on weekly `gcc-13` snapshot as:

    frontend/qt/qtkey.h:25:19: error: 'uint32_t' was not declared in this scope
       25 | int keysymToQtKey(uint32_t keysym, const QString &text);
          |                   ^~~~~~~~