### PR TITLE
fcitx-gclient: Export fcitx_client_enable_ic, fcitx_client_close_ic

### DIFF
--- a/src/lib/fcitx-gclient/fcitxclient.h
+++ b/src/lib/fcitx-gclient/fcitxclient.h
@@ -88,6 +88,9 @@ void fcitx_client_set_capacity(FcitxClient *self, guint flags);
 
 void fcitx_client_reset(FcitxClient *self);
 
+void fcitx_client_enable_ic(FcitxClient *self);
+void fcitx_client_close_ic(FcitxClient *self);
+
 G_END_DECLS
 
 #endif // CLIENT_IM_H


### PR DESCRIPTION
These functions are used from fcitx-fbterm.  Adding function prototypes to the installed header file seems to be the cleanest way to ensure that fcitx-fbterm does not rely on implicit function declarations (which are likely to result in errors with future compilers by default).

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
