### PR TITLE
fstat(3): Support large inode (>=2^32) on 32 bits system

### DIFF
--- a/src/im/pinyin/py.c
+++ b/src/im/pinyin/py.c
@@ -19,6 +19,7 @@
  ***************************************************************************/
 #include "config.h"
 
+#define _FILE_OFFSET_BITS 64
 #include <libintl.h>
 #include <stdio.h>
 #include <limits.h>

--- a/src/lib/fcitx-config/xdg.c
+++ b/src/lib/fcitx-config/xdg.c
@@ -27,7 +27,7 @@
  */
 
 #define FCITX_CONFIG_XDG_DEPRECATED
-
+#define _FILE_OFFSET_BITS 64
 #include "config.h"
 
 #include <limits.h>

--- a/src/lib/fcitx-utils/utils.h
+++ b/src/lib/fcitx-utils/utils.h
@@ -60,6 +60,7 @@
 #ifndef _FCITX_UTILS_H_
 #define _FCITX_UTILS_H_
 
+#define _FILE_OFFSET_BITS 64
 #include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>

--- a/src/module/spell/dict/comp_spell_dict.c
+++ b/src/module/spell/dict/comp_spell_dict.c
@@ -17,7 +17,7 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.              *
  ***************************************************************************/
-
+#define _FILE_OFFSET_BITS 64
 #include "fcitx-utils/log.h"
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/module/spell/spell-custom-dict.c
+++ b/src/module/spell/spell-custom-dict.c
@@ -17,7 +17,7 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.              *
  ***************************************************************************/
-
+#define _FILE_OFFSET_BITS 64
 #include "fcitx/fcitx.h"
 #include "config.h"
 


### PR DESCRIPTION
This fix a problem when a file located in a large inode.